### PR TITLE
Added data-external

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vembedr
 Title: Embed Video in HTML
-Version: 0.1.4.9002
+Version: 0.1.4.9003
 Authors@R: c(
     person(
       given = "Ian", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vembedr 0.1.4.9000 (development version)
 
+- updates `<iframe>` implementation to keep up with pandoc, see [rstudio/rmarkdown#2255](https://github.com/rstudio/rmarkdown/issues/2255) (#52,  @jnolis).
+
 - version bump for development
 
 ## vembedr 0.1.4
@@ -17,7 +19,7 @@
 
 ## vembedr 0.1.3
 
-- updates README to show some custom formatting (#25, thanks @koncina and @ginolhac)
+- updates README to show some custom formatting (#25, @koncina & @ginolhac)
 - deprecates `hms()` and `secs()` in favor of `use_start_time()` (#24)
 - adds function `embed_user2017()`: embed videos from UseR!2017
 - version bump for development

--- a/R/service-box.R
+++ b/R/service-box.R
@@ -35,7 +35,8 @@ embed_box <- function(id, custom_domain = getOption("vembedr.box_custom_domain")
     frameborder = frameborder,
     allowfullscreen = allowfullscreen,
     webkitallowfullscreen = allowfullscreen,
-    msallowfullscreen = allowfullscreen
+    msallowfullscreen = allowfullscreen,
+    `data-external` = 1
   )
 
   embed <- create_embed(iframe, "vembedr_embed_box", ratio)

--- a/R/service-channel9.R
+++ b/R/service-channel9.R
@@ -19,7 +19,8 @@ embed_channel9 <- function(id,
     width = dim$width,
     height = dim$height,
     frameborder = frameborder,
-    allowfullscreen = allowfullscreen
+    allowfullscreen = allowfullscreen,
+    `data-external` = 1
   )
 
   embed <- create_embed(iframe, "vembedr_embed_channel9", ratio)

--- a/R/service-msstream.R
+++ b/R/service-msstream.R
@@ -17,7 +17,8 @@ embed_msstream <- function(id, width = NULL, height = 300,
     width = dim$width,
     height = dim$height,
     allowfullscreen = NULL,
-    style = "border:none;"
+    style = "border:none;",
+    `data-external` = 1
   )
 
   embed <- create_embed(iframe, "vembedr_embed_msstream", ratio)

--- a/R/service-vimeo.R
+++ b/R/service-vimeo.R
@@ -26,7 +26,8 @@ embed_vimeo <- function(id,
     frameborder = frameborder,
     webkitallowfullscreen = allowfullscreen,
     mozallowfullscreen = allowfullscreen,
-    allowfullscreen = allowfullscreen
+    allowfullscreen = allowfullscreen,
+    `data-external` = 1
   )
 
   embed <- create_embed(iframe, "vembedr_embed_vimeo", ratio)

--- a/R/service-youtube.R
+++ b/R/service-youtube.R
@@ -21,7 +21,8 @@ embed_youtube <- function(id,
     width = dim$width,
     height = dim$height,
     frameborder = frameborder,
-    allowfullscreen = allowfullscreen
+    allowfullscreen = allowfullscreen,
+    `data-external` = 1
   )
 
   embed <- create_embed(iframe, "vembedr_embed_youtube", ratio)


### PR DESCRIPTION
As noted in https://github.com/rstudio/rmarkdown/issues/2255 there is an issue with RMarkdown files rendering iframes since the RMarkdown file tries to embed the data. I took the fixed presented and added it to the five video types, which should resolve the problem. I tested it worked with a YouTube video (but not the rest).